### PR TITLE
Camera fix

### DIFF
--- a/components/HomeScreen.js
+++ b/components/HomeScreen.js
@@ -13,7 +13,8 @@ const HomeScreen = ({ setCamera, navigation }) => {
     });
     navigation.addListener('blur', () => {
       setIsFocused(false);
-    })(async () => {
+    });
+    (async () => {
       const { status } = await Camera.requestCameraPermissionsAsync();
       setHasPermission(status === 'granted');
     })();

--- a/components/HomeScreen.js
+++ b/components/HomeScreen.js
@@ -3,17 +3,25 @@ import { View, Text, StyleSheet } from 'react-native';
 import { Camera } from 'expo-camera';
 import PropTypes from 'prop-types';
 
-const HomeScreen = ({ setCamera }) => {
+const HomeScreen = ({ setCamera, navigation }) => {
   const [hasPermission, setHasPermission] = useState(null);
+  const [isFocused, setIsFocused] = useState(false);
 
   useEffect(() => {
-    (async () => {
+    navigation.addListener('focus', () => {
+      setIsFocused(true);
+    });
+    navigation.addListener('blur', () => {
+      setIsFocused(false);
+    })(async () => {
       const { status } = await Camera.requestCameraPermissionsAsync();
       setHasPermission(status === 'granted');
     })();
   }, []);
 
-  if (hasPermission === null || hasPermission === false) {
+  if (hasPermission === null) {
+    return <View />;
+  } else if (hasPermission === false) {
     return (
       <View style={styles.container}>
         <Text style={styles.error}>
@@ -22,18 +30,21 @@ const HomeScreen = ({ setCamera }) => {
         </Text>
       </View>
     );
+  } else if (isFocused === true) {
+    return (
+      <View style={styles.container}>
+        <Camera
+          style={styles.camera}
+          type={Camera.Constants.Type.back}
+          ref={(r) => {
+            setCamera(r);
+          }}
+        />
+      </View>
+    );
   }
-  return (
-    <View style={styles.container}>
-      <Camera
-        style={styles.camera}
-        type={Camera.Constants.Type.back}
-        ref={(r) => {
-          setCamera(r);
-        }}
-      />
-    </View>
-  );
+
+  return <View />;
 };
 
 const styles = StyleSheet.create({
@@ -52,6 +63,7 @@ const styles = StyleSheet.create({
 
 HomeScreen.propTypes = {
   setCamera: PropTypes.func,
+  navigation: PropTypes.object,
 };
 
 export default HomeScreen;


### PR DESCRIPTION
On Android, react tried to render a second expo-camera component when navigating back to HomeScreen. This is not allowed. 

Solved by un-mounting the Camera when navigating away from HomeScreen using navigation event listeners.